### PR TITLE
fixes #5 old ASM interface causes StackOverflowException.

### DIFF
--- a/src/main/java/com/github/stigmata/birthmarks/kgram/OpcodeExtractionMethodVisitor.java
+++ b/src/main/java/com/github/stigmata/birthmarks/kgram/OpcodeExtractionMethodVisitor.java
@@ -65,9 +65,9 @@ public class OpcodeExtractionMethodVisitor extends MethodVisitor{
 
     @Override
     public void visitMethodInsn(int opcode, String owner,
-				String name, String desc){
+                                String name, String desc, boolean itf){
         opcodes.add(opcode);
-        super.visitMethodInsn(opcode, owner, name, desc, opcode == Opcodes.INVOKEINTERFACE);
+        super.visitMethodInsn(opcode, owner, name, desc, itf);
     }
 
     @Override

--- a/src/main/java/com/github/stigmata/cflib/OpcodeExtractMethodVisitor.java
+++ b/src/main/java/com/github/stigmata/cflib/OpcodeExtractMethodVisitor.java
@@ -121,7 +121,7 @@ public class OpcodeExtractMethodVisitor extends MethodVisitor{
     }
 
     @Override
-    public void visitMethodInsn(int opcode, String owner, String name, String desc){
+    public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf){
         Opcode methodOpcode = new Opcode(manager.getOpcode(opcode));
         Type[] types = Type.getArgumentTypes(desc);
         int argumentSize = 0;
@@ -142,7 +142,7 @@ public class OpcodeExtractMethodVisitor extends MethodVisitor{
         methodOpcode.setAct(size);
 
         opcodes.add(methodOpcode);
-        super.visitMethodInsn(opcode, owner, name, desc, opcode == Opcodes.INVOKEINTERFACE);
+        super.visitMethodInsn(opcode, owner, name, desc, itf);
     }
 
     @Override


### PR DESCRIPTION
We update new ASM interface, use visitMethodInsn(String, String, String, String, boolean) method instead of visitMethodInsn(String, String, String, String) method.
